### PR TITLE
Update FeatureContext.php

### DIFF
--- a/src/FeatureContext.php
+++ b/src/FeatureContext.php
@@ -39,8 +39,12 @@ class FeatureContext extends RawMinkContext {
    */
   public function iManipulateDateAndExecuteCmd($date, $command) {
     $instruction = 'LD_PRELOAD=' . $this->parameters['install_path'] . ' FAKETIME="' . $date . '" ' . $command;
-    $result = explode(PHP_EOL, shell_exec($instruction . ' 2>&1'));
-    return $result[0];
+    $exec_result = shell_exec($instruction . ' 2>&1');
+    if ($exec_result) {
+      $result = explode(PHP_EOL, $exec_result);
+      return $result[0];
+    }
+    return $exec_result;
   }
 
 }


### PR DESCRIPTION
Fix error "explode(): Passing null to parameter #2 ($string) of type string is deprecated in vendor/dazzle/behat-date-manipulation/src/FeatureContext.php line 42" if shell_exec doesn't have output.